### PR TITLE
got cmake to run on a Linux host

### DIFF
--- a/cmake/defaults/CXXDefaults.cmake
+++ b/cmake/defaults/CXXDefaults.cmake
@@ -1,5 +1,5 @@
 
-include(CXXHelpers)
+include(CXXhelpers)
 
 if (CMAKE_COMPILER_IS_GNUCXX)
     include(gccdefaults)

--- a/cmake/defaults/CXXhelpers.cmake
+++ b/cmake/defaults/CXXhelpers.cmake
@@ -14,7 +14,9 @@ function(_disable_warning flag)
 endfunction()
 
 function(_set_Cxx17 proj)
+    if(APPLE OR WIN32)
 	target_compile_features(${proj} INTERFACE cxx_std_17)
+    endif()
 endfunction()
 
 function(_set_compile_options proj)

--- a/cmake/libnyquist.cmake
+++ b/cmake/libnyquist.cmake
@@ -1,7 +1,7 @@
 
 #-------------------------------------------------------------------------------
 
-include(CXXHelpers)
+include(CXXhelpers)
 
 project(libopus)
 


### PR DESCRIPTION
This is a follow-on to issue #66. It allows for cmake to successfully complete execution on a Linux system.

This pull request was tested on CentOS 7 and regression tested on macOS.

In a comment on #66, meshula mentions he hasn't got a linux machine to test with. I would happily provide a log-in for the CentOS 7 box I'm doing this work on, which is running as an AWS EC2 instance.