### PR TITLE
some incremental progress on getting cmake to run on Linux

### DIFF
--- a/cmake/defaults/CXXDefaults.cmake
+++ b/cmake/defaults/CXXDefaults.cmake
@@ -1,5 +1,5 @@
 
-include(CXXHelpers)
+include(CXXhelpers)
 
 if (CMAKE_COMPILER_IS_GNUCXX)
     include(gccdefaults)

--- a/cmake/defaults/gccdefaults.cmake
+++ b/cmake/defaults/gccdefaults.cmake
@@ -1,0 +1,1 @@
+include(gccclangshareddefaults)

--- a/cmake/libnyquist.cmake
+++ b/cmake/libnyquist.cmake
@@ -1,7 +1,7 @@
 
 #-------------------------------------------------------------------------------
 
-include(CXXHelpers)
+include(CXXhelpers)
 
 project(libopus)
 


### PR DESCRIPTION
Baby steps towards a successful Linux cmake. Still not there though, still get this error even with this pull request:

```
Make Error at cmake/libnyquist.cmake:95 (add_library):
  Cannot find source file:

    /home/centos/LabSound/third_party/libnyquist/src/ModPlugDecoder.cpp

  Tried extensions .c .C .c++ .cc .cpp .cxx .m .M .mm .h .hh .h++ .hm .hpp
  .hxx .in .txx
Call Stack (most recent call first):
  CMakeLists.txt:24 (include)


CMake Error: Cannot determine link language for target "libnyquist".
CMake Error: CMake can not determine linker language for target: libnyquist
```

See issue #66 for the full discussion.