### PR TITLE
Add optional sample_rate to MakeRealtimeAudioContext()

### DIFF
--- a/include/LabSound/extended/LabSound.h
+++ b/include/LabSound/extended/LabSound.h
@@ -58,7 +58,7 @@ namespace lab
 {
     // These are convenience functions with straightforward definitions. Most of the samples use them, but they are not strictly required. 
     std::shared_ptr<AudioHardwareSourceNode> MakeHardwareSourceNode(ContextRenderLock & r);
-    std::unique_ptr<AudioContext> MakeRealtimeAudioContext();
+    std::unique_ptr<AudioContext> MakeRealtimeAudioContext(float sample_rate = 44100.f);
     std::unique_ptr<AudioContext> MakeOfflineAudioContext(float recordTimeMilliseconds);
     std::unique_ptr<AudioContext> MakeOfflineAudioContext(int numChannels, float recordTimeMilliseconds, float sample_rate);
 }

--- a/src/extended/LabSound.cpp
+++ b/src/extended/LabSound.cpp
@@ -26,11 +26,11 @@ namespace lab
         return inputNode;
     }
 
-    std::unique_ptr<lab::AudioContext> MakeRealtimeAudioContext()
+    std::unique_ptr<lab::AudioContext> MakeRealtimeAudioContext(float sample_rate)
     {
         LOG("Initialize Realtime Context");
         std::unique_ptr<AudioContext> ctx(new lab::AudioContext(false));
-        ctx->setDestinationNode(std::make_shared<lab::DefaultAudioDestinationNode>(ctx.get(), 44100));
+        ctx->setDestinationNode(std::make_shared<lab::DefaultAudioDestinationNode>(ctx.get(), sample_rate));
         ctx->lazyInitialize();
         return ctx;
     }


### PR DESCRIPTION
As `MakeRealtimeAudioContext` is a convenience function for `AudioContext` creation, it should also be possible to pass a custom `sample_rate` value. This parameter is optional in WAA-spec, as you can see [here](https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/AudioContext). So any WAA-compliant bindings will be able to benefit from `MakeRealtimeAudioContext` only if it has this parameter. Otherwise such bindings would start repeating `MakeRealtimeAudioContext`'s code.