### PR TITLE
set m_endTime to UnknownTime when reseting an AudioScheduledSourceNode

### DIFF
--- a/include/LabSound/core/AudioScheduledSourceNode.h
+++ b/include/LabSound/core/AudioScheduledSourceNode.h
@@ -42,7 +42,7 @@ public:
 
     bool hasFinished() const { return m_playbackState == FINISHED_STATE; }
 
-    virtual void reset(ContextRenderLock&) override { m_playbackState = UNSCHEDULED_STATE; }
+    virtual void reset(ContextRenderLock&) override;
 
     // LabSound: If the node included ScheduledNode in its hierarchy, this will return true.
     // This is to save the cost of a dynamic_cast when scheduling nodes.

--- a/src/core/AudioScheduledSourceNode.cpp
+++ b/src/core/AudioScheduledSourceNode.cpp
@@ -142,6 +142,11 @@ void AudioScheduledSourceNode::stop(double when)
     m_endTime = when;
 }
 
+void AudioScheduledSourceNode::reset(ContextRenderLock&) {
+    m_playbackState = UNSCHEDULED_STATE;
+    m_endTime = UnknownTime;
+}
+
 void AudioScheduledSourceNode::finish(ContextRenderLock& r)
 {
     m_playbackState = FINISHED_STATE;


### PR DESCRIPTION
This sets `m_endTime` back to its initial value (`UnknownTime` which is -1) when `reset()` is called. I needed this in order to support replaying a **SampledAudioNode** after it calling `start()` and `stop()` on it.

If there's a better way to accomplish this that I'm missing, this PR isn't needed.