### PR TITLE
AudioDestinationDarwin: handle error for AudioComponentInstanceNew

### DIFF
--- a/src/backends/darwin/AudioDestinationDarwin.cpp
+++ b/src/backends/darwin/AudioDestinationDarwin.cpp
@@ -43,7 +43,7 @@ public:
         ASSERT(comp);
 
         OSStatus result = AudioComponentInstanceNew(comp, &m_inputUnit);
-        if (!result)
+        if (result != noErr)
         {
             AudioComponentInstanceDispose(m_inputUnit);
             m_inputUnit = 0;


### PR DESCRIPTION
This seems to have been introduced in 6cdafb829e0bac00c9d2cd62a4f6c2cda7aa5dce.

`result` is zero when there is no error (`noErr` is zero). Currently we are accidentally branching to the error case instead of the "happy path". Explicitly compare against `noErr` for readability. 

Fixes #131