### PR TITLE
Check if default devices really are

### DIFF
--- a/src/backends/windows/AudioDestinationWindows.cpp
+++ b/src/backends/windows/AudioDestinationWindows.cpp
@@ -97,10 +97,12 @@ void AudioDestinationWin::configure()
 
     try
     {
-        dac.openStream(outDeviceInfo.probed ? &outputParams : nullptr, 
-                       inDeviceInfo.probed ? &inputParams : nullptr, 
-            RTAUDIO_FLOAT32, 
-            (unsigned int) m_sampleRate, &bufferFrames, &outputCallback, this, &options);
+        dac.openStream(
+            outDeviceInfo.probed && outDeviceInfo.isDefaultOutput ? &outputParams : nullptr,
+            inDeviceInfo.probed && inDeviceInfo.isDefaultInput ? &inputParams : nullptr,
+            RTAUDIO_FLOAT32,
+            (unsigned int) m_sampleRate, &bufferFrames, &outputCallback, this, &options
+        );
     }
     catch (RtAudioError & e)
     {


### PR DESCRIPTION
In case there is no mic in the system, `getDefaultInputDevice()` still says `0`, yet it may point to an existing output device, wreaking havoc... Prevent that.

The error was on Windows, "RtApiWasapi::probeDeviceOpen: Render device selected as input device.". I don't know if simillar issues occur on OSX and Linux, I only debugged the windows backend.