### PR TITLE
Add backendReinitialize method

### DIFF
--- a/include/LabSound/core/AudioDevice.h
+++ b/include/LabSound/core/AudioDevice.h
@@ -114,6 +114,7 @@ public:
 
     virtual ~AudioDevice() {}
     virtual void start() = 0;
+    virtual void backendReinitialize() {}
     virtual void stop() = 0;
     virtual bool isRunning() const = 0;
 };

--- a/include/LabSound/core/AudioDevice.h
+++ b/include/LabSound/core/AudioDevice.h
@@ -114,9 +114,9 @@ public:
 
     virtual ~AudioDevice() {}
     virtual void start() = 0;
-    virtual void backendReinitialize() {}
     virtual void stop() = 0;
     virtual bool isRunning() const = 0;
+    virtual void backendReinitialize() {}
 };
 
 }  // lab

--- a/include/LabSound/core/AudioHardwareDeviceNode.h
+++ b/include/LabSound/core/AudioHardwareDeviceNode.h
@@ -47,6 +47,8 @@ public:
     virtual void initialize() override;
     virtual void uninitialize() override;
 
+    virtual void backendReinitialize();
+
     // AudioDeviceRenderCallback interface
     virtual void render(AudioBus * src, AudioBus * dst, int frames, const SamplingInfo & info) override;
     virtual void start() override;

--- a/src/backends/miniaudio/AudioDevice_Miniaudio.cpp
+++ b/src/backends/miniaudio/AudioDevice_Miniaudio.cpp
@@ -229,6 +229,34 @@ AudioDevice_Miniaudio::~AudioDevice_Miniaudio()
         free(_scratch);
 }
 
+void AudioDevice_Miniaudio::backendReinitialize()
+{
+    auto device_list = AudioDevice::MakeAudioDeviceList();
+    PrintAudioDeviceList();
+
+    //ma_device_config deviceConfig = ma_device_config_init(ma_device_type_duplex);
+    ma_device_config deviceConfig = ma_device_config_init(ma_device_type_playback);
+    deviceConfig.playback.format = ma_format_f32;
+    deviceConfig.playback.channels = outputConfig.desired_channels;
+    deviceConfig.sampleRate = static_cast<int>(outputConfig.desired_samplerate);
+    deviceConfig.capture.format = ma_format_f32;
+    deviceConfig.capture.channels = inputConfig.desired_channels;
+    deviceConfig.dataCallback = outputCallback;
+    deviceConfig.performanceProfile = ma_performance_profile_low_latency;
+    deviceConfig.pUserData = this;
+
+#ifdef __WINDOWS_WASAPI__
+    deviceConfig.wasapi.noAutoConvertSRC = true;
+#endif
+
+    if (ma_device_init(&g_context, &deviceConfig, &_device) != MA_SUCCESS)
+    {
+        LOG_ERROR("Unable to open audio playback device");
+        return;
+    }
+}
+
+
 void AudioDevice_Miniaudio::start()
 {
     ASSERT(authoritativeDeviceSampleRateAtRuntime != 0.f);  // something went very wrong

--- a/src/backends/miniaudio/AudioDevice_Miniaudio.h
+++ b/src/backends/miniaudio/AudioDevice_Miniaudio.h
@@ -226,6 +226,7 @@ public:
     virtual void start() override final;
     virtual void stop() override final;
     virtual bool isRunning() const override final;
+    virtual void backendReinitialize() override final;
 };
 
 }  // namespace lab

--- a/src/core/AudioHardwareDeviceNode.cpp
+++ b/src/core/AudioHardwareDeviceNode.cpp
@@ -105,6 +105,11 @@ void AudioHardwareDeviceNode::start()
     }
 }
 
+void AudioHardwareDeviceNode::backendReinitialize()
+{
+    m_platformAudioDevice->backendReinitialize();
+}
+
 void AudioHardwareDeviceNode::stop()
 {
     m_platformAudioDevice->stop();


### PR DESCRIPTION
In Android if the audio device is switched, it will cause the playback to stop and need to reinitialize miniaudio.