### PR TITLE
Fix `SampledAudioNode` not receiving onEnded event when executing `stop`

### DIFF
--- a/src/core/AudioNode.cpp
+++ b/src/core/AudioNode.cpp
@@ -127,6 +127,8 @@ bool AudioNodeScheduler::update(ContextRenderLock & r, int epoch_length)
                 // scheduled stop has occured, so make sure stop doesn't immediately trigger again
                 _stopWhen = std::numeric_limits<uint64_t>::max();
                 _playbackState = SchedulingState::UNSCHEDULED;
+                if(_onEnded)
+                    r.context()->enqueueEvent(_onEnded);
                 ASN_PRINT("unscheduled\n");
             }
             break;


### PR DESCRIPTION
Thanks for telling me the right way, I created a clean PR.