### PR TITLE
Modify cmake_minimum_required, android has LABSOUND_PULSE turned on by mistake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+# Android studio still commonly requires a minimum version of 3.10
 cmake_minimum_required(VERSION 3.10)
 include_guard()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.10)
 include_guard()
 
 project(LabSound)
@@ -10,6 +10,7 @@ set(LABSOUND_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")
 
 if (WIN32)
 elseif (APPLE)
+elseif (ANDROID)
 else()
     if (NOT LABSOUND_JACK AND NOT LABSOUND_PULSE AND NOT LABSOUND_ASOUND)
         message(STATUS "No Linux backend specified, defaulting to Pulse.")


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5716100/120885094-9dde3680-c619-11eb-8004-0ba6ac7bda37.png)
Android Studio provides a small number of versions of CMake. I would like to lower the minimum version requirement to 3.10 so that users can configure the environment more easily.
I modified it and it runs fine, I don't know if it will cause other problems.
If possible, `libnyquist` needs to be modified as well.

Compiling android in mac will prompt that `Pulse` is not found, this library is for linux, I skipped its default setting.
