### PR TITLE
Revert "Modify cmake_minimum_required"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LABSOUND_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")
 
 if (WIN32)
 elseif (APPLE)
+elseif (ANDROID)
 else()
     if (NOT LABSOUND_JACK AND NOT LABSOUND_PULSE AND NOT LABSOUND_ASOUND)
         message(STATUS "No Linux backend specified, defaulting to Pulse.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 
-# Android studio still commonly requires a minimum version of 3.10
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 include_guard()
 
 project(LabSound)
@@ -11,7 +10,6 @@ set(LABSOUND_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")
 
 if (WIN32)
 elseif (APPLE)
-elseif (ANDROID)
 else()
     if (NOT LABSOUND_JACK AND NOT LABSOUND_PULSE AND NOT LABSOUND_ASOUND)
         message(STATUS "No Linux backend specified, defaulting to Pulse.")


### PR DESCRIPTION
Reverts LabSound/LabSound#161

I'm working on a Flutter plugin for LabSound. Previously, the 3.18.1 cmake was not working properly due to a bug in flutter. Now I upgraded Flutter and the 2.18.1 cmake is working properly. 

I think lowering cmake_minimum_required is no longer necessary. I think I should revert this PR.

Lowering cmake causes `set` to fail to override `option`, causing the example with `libnyquist` disabled to fail.

I'm sorry for filing a PR without detailed investigation.
