### PR TITLE
Fix build errors on MSYS2 (Windows)

### DIFF
--- a/cmake/LabSound.cmake
+++ b/cmake/LabSound.cmake
@@ -161,10 +161,12 @@ function (configureProj proj)
     )
     set_property(TARGET ${proj} PROPERTY CXX_STANDARD 17)
     if(WIN32)
-        # Arch AVX is problematic for many users, so disable it until
-        # some reasonable strategy (a separate AVX target?) is determined
-        #target_compile_options(${proj} PRIVATE /arch:AVX /Zi)
-        target_compile_options(${proj} PRIVATE /Zi)
+        if(MSVC)
+            # Arch AVX is problematic for many users, so disable it until
+            # some reasonable strategy (a separate AVX target?) is determined
+            #target_compile_options(${proj} PRIVATE /arch:AVX /Zi)
+            target_compile_options(${proj} PRIVATE /Zi)
+        endif(MSVC)
         # TODO: These vars are for libnyquist and should be set in the find libynquist script.
         target_compile_definitions(${proj} PRIVATE HAVE_STDINT_H=1 HAVE_SINF=1)
     elseif(APPLE)

--- a/cmake/examples.cmake
+++ b/cmake/examples.cmake
@@ -82,6 +82,10 @@ if (NOT IOS)
 target_link_libraries(LabSoundExample LabSound LabSoundRtAudio)
 endif()
 
+if(MINGW)
+    target_link_libraries(LabSoundExample mfuuid mfplat ksuser wmcodecdspuuid)
+endif(MINGW)
+
 set_target_properties(LabSoundExample PROPERTIES
                       RUNTIME_OUTPUT_DIRECTORY bin)
 

--- a/cmake/examples.cmake
+++ b/cmake/examples.cmake
@@ -11,10 +11,12 @@ set(CMAKE_CXX_STANDARD 14)
 set(proj LabSoundExample)
 
 if(WIN32)
-    # Arch AVX is problematic for many users, so disable it until
-    # some reasonable strategy (a separate AVX target?) is determined
-    #target_compile_options(${proj} PRIVATE /arch:AVX /Zi)
-    target_compile_options(${proj} PRIVATE /Zi)
+    if(MSVC)
+        # Arch AVX is problematic for many users, so disable it until
+        # some reasonable strategy (a separate AVX target?) is determined
+        #target_compile_options(${proj} PRIVATE /arch:AVX /Zi)
+        target_compile_options(${proj} PRIVATE /Zi)
+    endif(MSVC)
     target_compile_definitions(${proj} PRIVATE __WINDOWS_WASAPI__=1)
     # TODO: These vars are for libniquist and should be set in the find libynquist script.
     target_compile_definitions(${proj} PRIVATE HAVE_STDINT_H=1 HAVE_SINF=1)


### PR DESCRIPTION
While building the library with GCC on MINGW32/MSYS2, I've encountered a few minor issues:

* The CMake build system passes MSVC compilation flags to GCC, which doesn't know what to do with them
* Some WMF libraries that rtaudio requires seem to not be linked in by default, leading to linker errors later on

After making these proposed changes, I'm now able to build and run both the library and the example (`LabSoundExample.exe`).