### PR TITLE
Fix an outdated reference to the VectorMath header

### DIFF
--- a/src/backends/miniaudio/AudioDevice_Miniaudio.cpp
+++ b/src/backends/miniaudio/AudioDevice_Miniaudio.cpp
@@ -6,12 +6,12 @@
 #include "LabSound/backends/AudioDevice_Miniaudio.h"
 
 #include "internal/Assertions.h"
-#include "internal/VectorMath.h"
 
 #include "LabSound/core/AudioDevice.h"
 #include "LabSound/core/AudioNode.h"
 
 #include "LabSound/extended/Logging.h"
+#include "LabSound/extended/VectorMath.h"
 
 #include <assert.h>
 


### PR DESCRIPTION
This object file will no longer build since the header has been moved. Edit: Also fixes the CI failures.