### PR TITLE
Remove a redundant debug printf in AudioNode.cpp

### DIFF
--- a/src/core/AudioNode.cpp
+++ b/src/core/AudioNode.cpp
@@ -423,9 +423,6 @@ std::shared_ptr<AudioNodeOutput> AudioNode::output(char const* const str)
 
 int AudioNode::channelCount()
 {
-    if (_self->m_channelCount == 0) {
-        printf("WUY\n");
-    }
     ASSERT(_self->m_channelCount != 0);
     return _self->m_channelCount;
 }


### PR DESCRIPTION
Looks like this was accidentally committed as part of 31ebf651.