### PR TITLE
Include the affected node's name in playback state updates

### DIFF
--- a/include/LabSound/core/AudioNodeScheduler.h
+++ b/include/LabSound/core/AudioNodeScheduler.h
@@ -46,7 +46,7 @@ public:
     SchedulingState playbackState() const { return _playbackState; }
     bool hasFinished() const { return _playbackState == SchedulingState::FINISHED; }
 
-    bool update(ContextRenderLock&, int epoch_length);
+    bool update(ContextRenderLock&, int epoch_length, const char* node_name);
 
     SchedulingState _playbackState = SchedulingState::UNSCHEDULED;
 


### PR DESCRIPTION
Currently, the ASN_PRINT macro simply displays the state, but it doesn't give any indication as to which node is being processed. This is one of the things that confused me while trying to debug the WaveShaper example. Initially, I didn't realize there was another node that caused the scheduler to print the same messages twice (from the same thread).

The good news is that there's no problem with the same node being processed twice, after all.

---

Example:

```sh
Scheduler: fade in (StereoPanner)
Scheduler: fade in (SampledAudio)
Scheduler: playing (StereoPanner)
Scheduler: playing (SampledAudio)
B i -2 curve[0] -1.000000 curve[44099] 0.999955 oversample none
Scheduler: fade in (WaveShaper)
Scheduler: fade in (Oscillator)
Scheduler: playing (WaveShaper)
Scheduler: playing (Oscillator)
B i -1 curve[0] -1.000000 curve[44099] 0.999973 oversample none
B i 0 curve[0] -1.000000 curve[44099] 0.999985 oversample none
```

Edit: This may be slightly awkward if a node doesn't have a real name (e.g., `""`). But AFAICT all nodes have readable names.