### PR TITLE
fix SampledAudioNode schedule function parameters cannot take effect bug

### DIFF
--- a/include/LabSound/backends/AudioDevice_Miniaudio.h
+++ b/include/LabSound/backends/AudioDevice_Miniaudio.h
@@ -37,8 +37,6 @@ public:
         const AudioStreamConfig & inputConfig);
     virtual ~AudioDevice_Miniaudio();
 
-    AudioStreamConfig outputConfig;
-    AudioStreamConfig inputConfig;
     float authoritativeDeviceSampleRateAtRuntime{0.f};
 
     // AudioDevice Interface

--- a/include/LabSound/core/AudioDevice.h
+++ b/include/LabSound/core/AudioDevice.h
@@ -182,7 +182,7 @@ public:
                 const SamplingInfo & info);
     
     
-    void offlineRender(AudioBus * dst, size_t framesToProcess);
+    void offlineRender(AudioBus * dst, int framesToProcess);
 
     const SamplingInfo & getSamplingInfo() const { return _last_info; }
     

--- a/src/core/AudioDevice.cpp
+++ b/src/core/AudioDevice.cpp
@@ -134,7 +134,7 @@ void AudioDestinationNode::render(AudioSourceProvider* provider,
     selfProfile.finalize();
 }
 
-void AudioDestinationNode::offlineRender(AudioBus * dst, size_t framesToProcess)
+void AudioDestinationNode::offlineRender(AudioBus * dst, int framesToProcess)
 {
     static const int offlineRenderSizeQuantum = AudioNode::ProcessingSizeInFrames;
 
@@ -162,7 +162,7 @@ void AudioDestinationNode::offlineRender(AudioBus * dst, size_t framesToProcess)
         _last_info.epoch[index] += std::chrono::nanoseconds {
                 static_cast<uint64_t>(1.e9 * (double) framesToProcess / (double) offlineRenderSizeQuantum)};
 
-        framesToProcess--;
+        framesToProcess -= offlineRenderSizeQuantum;
     }
 }
 

--- a/src/core/SampledAudioNode.cpp
+++ b/src/core/SampledAudioNode.cpp
@@ -290,7 +290,7 @@ namespace lab {
             _self->_scheduler.start(0.);
 
         std::shared_ptr<AudioBus> bus = m_pendingSourceBus;
-        if (!bus) {
+        if (bus) {
             float r = bus->sampleRate();
             int32_t grainStart = static_cast<uint32_t>(grainOffset * r);
             int32_t grainEnd = grainStart + static_cast<uint32_t>(grainDuration * r);


### PR DESCRIPTION
in SampledAudioNode, function SampledAudioNode::schedule(float when, float grainOffset, float grainDuration, int loopCount) has a bug, modify "if(!bus)" to "if(bus)", the four parameters can effect