### PR TITLE
fix PingPongDelayNode BuildSubgraph connect nodes bug

### DIFF
--- a/include/LabSound/backends/AudioDevice_Miniaudio.h
+++ b/include/LabSound/backends/AudioDevice_Miniaudio.h
@@ -37,8 +37,6 @@ public:
         const AudioStreamConfig & inputConfig);
     virtual ~AudioDevice_Miniaudio();
 
-    AudioStreamConfig outputConfig;
-    AudioStreamConfig inputConfig;
     float authoritativeDeviceSampleRateAtRuntime{0.f};
 
     // AudioDevice Interface

--- a/include/LabSound/core/AudioDevice.h
+++ b/include/LabSound/core/AudioDevice.h
@@ -182,7 +182,7 @@ public:
                 const SamplingInfo & info);
     
     
-    void offlineRender(AudioBus * dst, size_t framesToProcess);
+    void offlineRender(AudioBus * dst, int framesToProcess);
 
     const SamplingInfo & getSamplingInfo() const { return _last_info; }
     

--- a/src/core/AudioDevice.cpp
+++ b/src/core/AudioDevice.cpp
@@ -134,7 +134,7 @@ void AudioDestinationNode::render(AudioSourceProvider* provider,
     selfProfile.finalize();
 }
 
-void AudioDestinationNode::offlineRender(AudioBus * dst, size_t framesToProcess)
+void AudioDestinationNode::offlineRender(AudioBus * dst, int framesToProcess)
 {
     static const int offlineRenderSizeQuantum = AudioNode::ProcessingSizeInFrames;
 
@@ -162,7 +162,7 @@ void AudioDestinationNode::offlineRender(AudioBus * dst, size_t framesToProcess)
         _last_info.epoch[index] += std::chrono::nanoseconds {
                 static_cast<uint64_t>(1.e9 * (double) framesToProcess / (double) offlineRenderSizeQuantum)};
 
-        framesToProcess--;
+        framesToProcess -= offlineRenderSizeQuantum;
     }
 }
 

--- a/src/core/SampledAudioNode.cpp
+++ b/src/core/SampledAudioNode.cpp
@@ -290,7 +290,7 @@ namespace lab {
             _self->_scheduler.start(0.);
 
         std::shared_ptr<AudioBus> bus = m_pendingSourceBus;
-        if (!bus) {
+        if (bus) {
             float r = bus->sampleRate();
             int32_t grainStart = static_cast<uint32_t>(grainOffset * r);
             int32_t grainEnd = grainStart + static_cast<uint32_t>(grainDuration * r);

--- a/src/extended/PingPongDelayNode.cpp
+++ b/src/extended/PingPongDelayNode.cpp
@@ -69,7 +69,7 @@ void PingPongDelayNode::BuildSubgraph(AudioContext & ac)
     ac.connect(splitter, input, 0, 0);
     
     ac.connect(splitterGain, splitter, 0, 0);
-    ac.connect(splitterGain, splitter, 1, 0);
+    ac.connect(splitterGain, splitter, 0, 1);
     
     ac.connect(wetGain, splitterGain, 0, 0);
     splitterGain->gain()->setValue(0.5f);
@@ -81,7 +81,7 @@ void PingPongDelayNode::BuildSubgraph(AudioContext & ac)
     ac.connect(feedbackGain, rightDelay, 0, 0);
     
     ac.connect(merger, leftDelay, 0, 0);
-    ac.connect(merger, rightDelay, 0, 1);
+    ac.connect(merger, rightDelay, 1, 0);
     
     ac.connect(output, merger, 0, 0);
     


### PR DESCRIPTION
before change, ac.connect(splitterGain, splitter, 1, 0) and ac.connect(merger, rightDelay, 0, 1) srcIndex destIndex were false, an error will be reported at runtime.