### PR TITLE
Enable get shared from ptr.

### DIFF
--- a/include/LabSound/core/AudioNode.h
+++ b/include/LabSound/core/AudioNode.h
@@ -70,7 +70,7 @@ class ContextRenderLock;
 // It may be an audio source, an intermediate processing module, or an audio 
 // destination.
 //
-class AudioNode
+class AudioNode : public std::enable_shared_from_this<AudioNode>
 {
 protected:
     // all storage to the node is in this struct ~ the graph and


### PR DESCRIPTION
# Problem
A lot of functions in LabSound either want the shared_ptr or the raw ptr,
sometimes you only get access to the raw ptr like when traversing the graph and you want to execute some LS function that requires a shared_ptr but currently theres no way to get the shared_ptr from a raw ptr.

# Possible solution
Enable `std::enable_shared_from_this`, I'm not 100% sure if this is a great solution but its been working for me. 