### PR TITLE
Remove copyright notice from MixNode.cpp

### DIFF
--- a/src/core/MixNode.cpp
+++ b/src/core/MixNode.cpp
@@ -1,5 +1,4 @@
 // License: BSD 2 Clause
-// Copyright (C) 2010, Google Inc. All rights reserved.
 // Copyright (C) 2015+, The LabSound Authors. All rights reserved.
 
 #include "LabSound/core/MixNode.h"


### PR DESCRIPTION
This isn't apart of googles copyright and I forgot to remove it from the source file. 😅