### PR TITLE
Web Audio correctness fixes: leaks, silent nodes, offline scheduling, and a multi-context crash

### DIFF
--- a/include/LabSound/backends/AudioDevice_Miniaudio.h
+++ b/include/LabSound/backends/AudioDevice_Miniaudio.h
@@ -24,6 +24,14 @@ class AudioDevice_Miniaudio : public AudioDevice
     float * _scratch = nullptr;
     int _remainder = 0;
 
+    // See AudioDevice_Miniaudio.cpp: the shared ma_context is reference-counted (with multiple coexisting
+    // AudioContexts the original code let every device destructor tear the shared context down -> a second
+    // uninit -> PulseAudio abort). _holdsContextRef: whether this device holds a context reference.
+    // _deviceInitialized: whether the ma_device actually initialized (decides whether the destructor
+    // stop()s / uninit()s it).
+    bool _holdsContextRef = false;
+    bool _deviceInitialized = false;
+
 public:
 
 #ifdef _MSC_VER

--- a/include/LabSound/core/AudioNodeScheduler.h
+++ b/include/LabSound/core/AudioNodeScheduler.h
@@ -53,6 +53,9 @@ public:
     // epoch is a long count at sample rate; 136 years at 48kHz
 
     std::atomic<uint64_t> _epoch{0}; // the epoch rendered currently in the busses
+    bool _firstUpdateDone = false;    // the first offline quantum has _epoch == proposed == 0, which the
+                                      // >= early-out below would skip, dropping the first quantum for a
+                                      // start(0) source; force the first update through (see update()).
     uint64_t _epochLength = 0;        // number of frames in current epoch
 
     // start and stop epoch (absolute, not relative)

--- a/src/backends/miniaudio/AudioDevice_Miniaudio.cpp
+++ b/src/backends/miniaudio/AudioDevice_Miniaudio.cpp
@@ -28,6 +28,7 @@
 
 #include "miniaudio.h"
 
+#include <mutex>
 #include <set>
 
 namespace lab
@@ -47,23 +48,69 @@ const int kRenderQuantum = AudioNode::ProcessingSizeInFrames;
 
 namespace
 {
+    // Reference-count the lifetime of the shared ma_context. g_context is a process-wide singleton (it
+    // hosts device enumeration and is passed to every ma_device_init), but the original
+    // ~AudioDevice_Miniaudio unconditionally called ma_context_uninit(&g_context). A page with two
+    // AudioContexts (e.g. SFX + music, which browsers allow) has two devices sharing it: the first device
+    // destroyed tears the shared context down, and the second device's destructor tears it down again.
+    // ma_context_uninit() does not zero the struct, so the second pass disconnects an already-freed backend
+    // context and PulseAudio aborts (`pa_atomic_load(&(c)->_ref) >= 1` failed at context.c); meanwhile any
+    // device still alive after the first teardown keeps running against a dangling context. Instead: init
+    // on demand when a reference is taken, and uninit only when the last reference is returned.
+    // g_context_mutex guards the ref count / init state (devices may be created and destroyed on different
+    // threads). g_devices is a pure value cache (strings/floats), independent of the context lifetime, so
+    // it is kept across inits.
     ma_context g_context;
     static std::vector<AudioDeviceInfo> g_devices;
     static bool g_must_init = true;
+    static int g_context_refs = 0;
+    static bool g_probed = false;
+    static std::mutex g_context_mutex;
 
-    void init_context()
+    // Caller must hold g_context_mutex.
+    bool init_context_locked()
     {
-        if (g_must_init)
+        if (!g_must_init)
+            return true;
+
+        LOG_TRACE("[LabSound] init_context() must_init");
+        if (ma_context_init(NULL, 0, NULL, &g_context) != MA_SUCCESS)
         {
-            LOG_TRACE("[LabSound] init_context() must_init");
-            if (ma_context_init(NULL, 0, NULL, &g_context) != MA_SUCCESS)
-            {
-                LOG_ERROR("[LabSound] init_context(): Failed to initialize miniaudio context");
-                return;
-            }
-            LOG_TRACE("[LabSound] init_context() succeeded");
-            g_must_init = false;
+            LOG_ERROR("[LabSound] init_context(): Failed to initialize miniaudio context");
+            return false;
         }
+        LOG_TRACE("[LabSound] init_context() succeeded");
+        g_must_init = false;
+        return true;
+    }
+
+    // Caller must hold g_context_mutex. Uninit only when the last reference is returned.
+    void release_context_locked()
+    {
+        if (g_context_refs <= 0)
+            return;
+        if (--g_context_refs == 0 && !g_must_init)
+        {
+            ma_context_uninit(&g_context);
+            g_must_init = true;
+        }
+    }
+
+    // Take a shared-context reference (initializing if needed). Each success must be paired with one
+    // release_context().
+    bool acquire_context()
+    {
+        std::lock_guard<std::mutex> lock(g_context_mutex);
+        if (!init_context_locked())
+            return false;
+        ++g_context_refs;
+        return true;
+    }
+
+    void release_context()
+    {
+        std::lock_guard<std::mutex> lock(g_context_mutex);
+        release_context_locked();
     }
 }
 
@@ -84,12 +131,20 @@ void PrintAudioDeviceList()
 
 std::vector<AudioDeviceInfo> AudioDevice_Miniaudio::MakeAudioDeviceList()
 {
-    init_context();
-    static bool probed = false;
-    if (probed)
+    // Hold a context reference for the duration of enumeration (otherwise, concurrently, another thread's
+    // device destructor could tear the context down mid-probe).
+    std::lock_guard<std::mutex> lock(g_context_mutex);
+    if (g_probed)
         return g_devices;
 
-    probed = true;
+    if (!init_context_locked())
+        return {};
+
+    ++g_context_refs;
+    struct ScopedRelease
+    {
+        ~ScopedRelease() { release_context_locked(); }
+    } scopedRelease;
 
     ma_result result;
     ma_device_info * pPlaybackDeviceInfos;
@@ -181,6 +236,8 @@ std::vector<AudioDeviceInfo> AudioDevice_Miniaudio::MakeAudioDeviceList()
         g_devices.push_back(lab_device_info);
     }
 
+    g_probed = true; // only cache on a successful probe (a failed probe retries next time; the original
+                     // code permanently returned an empty list after one failure)
     return g_devices;
 }
 
@@ -219,11 +276,24 @@ AudioDevice_Miniaudio::AudioDevice_Miniaudio(const AudioStreamConfig & _inputCon
     deviceConfig.wasapi.noAutoConvertSRC = true;
 #endif
 
+    // Hold a shared-context reference for the device's lifetime (returned in the destructor; the last
+    // device out calls uninit).
+    if (!acquire_context())
+    {
+        LOG_ERROR("Unable to initialize miniaudio context");
+        return;
+    }
+    _holdsContextRef = true;
+
     if (ma_device_init(&g_context, &deviceConfig, _device) != MA_SUCCESS)
     {
         LOG_ERROR("Unable to open audio playback device");
+        release_context(); // failed to open the device: return the reference immediately rather than
+                           // leaving the shared context tied to a half-dead device
+        _holdsContextRef = false;
         return;
     }
+    _deviceInitialized = true;
 
     authoritativeDeviceSampleRateAtRuntime = _outConfig.desired_samplerate;
 
@@ -236,10 +306,22 @@ AudioDevice_Miniaudio::AudioDevice_Miniaudio(const AudioStreamConfig & _inputCon
 
 AudioDevice_Miniaudio::~AudioDevice_Miniaudio()
 {
-    stop();
-    ma_device_uninit(_device);
-    ma_context_uninit(&g_context);
-    g_must_init = true;
+    // (1) Only tear down a ma_device that actually initialized (on a failed open, _device is a zeroed
+    // struct and stop()/uninit() on it just logs "Unable to stop audio device" noise). (2) Return the
+    // shared-context reference instead of unconditionally uninit-ing it: with multiple coexisting devices
+    // the original code let the first device destroyed tear down a context others were still using, and the
+    // second destructor tore it down again -> PulseAudio abort (see the note above).
+    if (_deviceInitialized)
+    {
+        stop();
+        ma_device_uninit(_device);
+        _deviceInitialized = false;
+    }
+    if (_holdsContextRef)
+    {
+        release_context();
+        _holdsContextRef = false;
+    }
     delete _renderBus;
     delete _inputBus;
     delete _ring;
@@ -268,11 +350,24 @@ void AudioDevice_Miniaudio::backendReinitialize()
     deviceConfig.wasapi.noAutoConvertSRC = true;
 #endif
 
+    // As in the constructor, reinitialization must hold a shared-context reference (not yet held if the
+    // constructor's device open failed).
+    if (!_holdsContextRef)
+    {
+        if (!acquire_context())
+        {
+            LOG_ERROR("Unable to initialize miniaudio context");
+            return;
+        }
+        _holdsContextRef = true;
+    }
+
     if (ma_device_init(&g_context, &deviceConfig, _device) != MA_SUCCESS)
     {
         LOG_ERROR("Unable to open audio playback device");
         return;
     }
+    _deviceInitialized = true;
 }
 
 

--- a/src/core/AnalyserNode.cpp
+++ b/src/core/AnalyserNode.cpp
@@ -103,6 +103,11 @@ AnalyserNode::AnalyserNode(AudioContext & ac)
 AnalyserNode::~AnalyserNode()
 {
     uninitialize();
+    // shared_construction() raw-news _detail (which owns the RealtimeAnalyser and its FFT
+    // buffers); the destructor never freed it, leaking ~28KB per AnalyserNode. ~Detail
+    // cascades the delete to m_analyser.
+    delete _detail;
+    _detail = nullptr;
 }
 
 void AnalyserNode::setMinDecibels(double k)

--- a/src/core/AudioContext.cpp
+++ b/src/core/AudioContext.cpp
@@ -447,6 +447,18 @@ void AudioContext::connect(std::shared_ptr<AudioNode> destination, std::shared_p
         throw std::out_of_range("Output index greater than available outputs");
     if (destIdx > destination->numberOfInputs())
         throw std::out_of_range("Input index greater than available inputs");
+    if (m_isOfflineContext)
+    {
+        // Offline contexts have no realtime render thread while control code runs; the async pending
+        // queue only lands on the first rendered quantum, so a connect->disconnect sequence before
+        // startRendering() renders with stale topology (WPT audionode-disconnect). Apply graph edits
+        // synchronously (the same two steps as handlePreRenderTasks' Connect case).
+        ContextGraphLock gLock(this, "AudioContext::connect(offline)");
+        AudioNodeInput::connect(gLock, destination->input(destIdx), source->output(srcIdx));
+        if (!source->isScheduledNode())
+            source->_self->_scheduler.start(0);
+        return;
+    }
     m_internal->pendingNodeConnections.enqueue({ConnectionOperationKind::Connect, destination, source, destIdx, srcIdx});
 }
 
@@ -458,6 +470,27 @@ void AudioContext::disconnect(std::shared_ptr<AudioNode> destination, std::share
         throw std::out_of_range("Output index greater than available outputs");
     if (destination && destIdx > destination->numberOfInputs())
         throw std::out_of_range("Input index greater than available inputs");
+    if (m_isOfflineContext)
+    {
+        // See connect(); this also skips the two-phase FinishDisconnect fade (a realtime anti-click
+        // nicety) -- offline disconnects must be sample-exact.
+        ContextGraphLock gLock(this, "AudioContext::disconnect(offline)");
+        if (destination && source)
+            AudioNodeInput::disconnect(gLock, destination->input(destIdx), source->output(srcIdx));
+        else if (destination)
+            for (int in = 0; in < destination->numberOfInputs(); ++in)
+            {
+                auto input = destination->input(in);
+                if (input) AudioNodeInput::disconnectAll(gLock, input);
+            }
+        else if (source)
+            for (int out = 0; out < source->numberOfOutputs(); ++out)
+            {
+                auto output = source->output(out);
+                if (output) AudioNodeOutput::disconnectAll(gLock, output);
+            }
+        return;
+    }
     m_internal->pendingNodeConnections.enqueue({ConnectionOperationKind::Disconnect, destination, source, destIdx, srcIdx});
 }
 
@@ -465,6 +498,22 @@ void AudioContext::disconnect(std::shared_ptr<AudioNode> node, int index)
 {
     if (!node)
         return;
+    if (m_isOfflineContext)
+    {
+        // Fully detach (inputs + outputs) synchronously.
+        ContextGraphLock gLock(this, "AudioContext::disconnect(offline)");
+        for (int in = 0; in < node->numberOfInputs(); ++in)
+        {
+            auto input = node->input(in);
+            if (input) AudioNodeInput::disconnectAll(gLock, input);
+        }
+        for (int out = 0; out < node->numberOfOutputs(); ++out)
+        {
+            auto output = node->output(out);
+            if (output) AudioNodeOutput::disconnectAll(gLock, output);
+        }
+        return;
+    }
     m_internal->pendingNodeConnections.enqueue({ConnectionOperationKind::Disconnect, node, std::shared_ptr<AudioNode>(), index, 0});
 }
 
@@ -493,6 +542,15 @@ void AudioContext::connectParam(std::shared_ptr<AudioParam> param, std::shared_p
         throw std::invalid_argument("No driving node supplied");
     if (index >= driver->numberOfOutputs())
         throw std::out_of_range("Output index greater than available outputs on the driver");
+    if (m_isOfflineContext)
+    {
+        // See connect().
+        ContextGraphLock gLock(this, "AudioContext::connectParam(offline)");
+        AudioParam::connect(gLock, param, driver->output(index));
+        if (!driver->isScheduledNode())
+            driver->_self->_scheduler.start(0);
+        return;
+    }
     m_internal->pendingParamConnections.enqueue({ConnectionOperationKind::Connect, param, driver, index});
 }
 
@@ -526,6 +584,13 @@ void AudioContext::disconnectParam(std::shared_ptr<AudioParam> param, std::share
     if (index >= driver->numberOfOutputs())
         throw std::out_of_range("Output index greater than available outputs on the driver");
 
+    if (m_isOfflineContext)
+    {
+        // See connect().
+        ContextGraphLock gLock(this, "AudioContext::disconnectParam(offline)");
+        AudioParam::disconnect(gLock, param, driver->output(index));
+        return;
+    }
     m_internal->pendingParamConnections.enqueue({ConnectionOperationKind::Disconnect, param, driver, index});
 }
 

--- a/src/core/AudioDevice.cpp
+++ b/src/core/AudioDevice.cpp
@@ -155,9 +155,13 @@ void AudioDestinationNode::offlineRender(AudioBus * dst, int framesToProcess)
         render(asp, 0, dst, offlineRenderSizeQuantum, _last_info);
 
         // Update sampling info
-        const int index = 1 - (_last_info.current_sample_frame & 1);
-        const uint64_t t = _last_info.current_sample_frame & ~1;
-        _last_info.current_sample_frame = t + offlineRenderSizeQuantum + index;
+        // Advance by exactly one quantum. The previous (frame & ~1) + quantum + index dance drifted
+        // current_sample_frame by +1 every other quantum, so a scheduled stop boundary lost one frame of
+        // renderLength (exact-sample tests dropped the last frame, 1023). epoch[] still ping-pongs by
+        // quantum index (a double-buffered clock, used offline only by getOutputTimestamp-style queries;
+        // current_time is taken from the frame count).
+        const int index = static_cast<int>(_last_info.current_sample_frame / offlineRenderSizeQuantum) & 1;
+        _last_info.current_sample_frame += offlineRenderSizeQuantum;
         _last_info.current_time = _last_info.current_sample_frame / static_cast<double>(_last_info.sampling_rate);
         _last_info.epoch[index] += std::chrono::nanoseconds {
                 static_cast<uint64_t>(1.e9 * (double) framesToProcess / (double) offlineRenderSizeQuantum)};

--- a/src/core/AudioNode.cpp
+++ b/src/core/AudioNode.cpp
@@ -250,9 +250,11 @@ void AudioNodeScheduler::start(double when)
         return;
     }
 
-    // Round rather than truncate: when * sr such as 1024/44100*44100 = 1023.9999 truncates to 1023,
-    // placing the boundary one frame early.
-    _startWhen = _epoch + static_cast<uint64_t>(when * _sampleRate + 0.5);
+    // Absolute frame: `when` is an absolute time per the Web Audio spec, not relative to the scheduler's
+    // _epoch. _epoch is 0 for a freshly created source but becomes currentSampleFrame once the source has
+    // been pulled, so an already-connected source started later drifted by ~currentTime. Round rather than
+    // truncate (1024/44100*44100 = 1023.9999 would truncate to 1023, one frame early).
+    _startWhen = static_cast<uint64_t>(when * _sampleRate + 0.5);
     _playbackState = SchedulingState::SCHEDULED;
 }
 
@@ -282,8 +284,8 @@ void AudioNodeScheduler::stop(double when)
         when = 0;
 
     // let the scheduler know when to activate the STOPPING state
-    // Round (as in start()) to avoid a boundary one frame early.
-    _stopWhen = _epoch + static_cast<uint64_t>(when * _sampleRate + 0.5);
+    // Absolute frame (see start()).
+    _stopWhen = static_cast<uint64_t>(when * _sampleRate + 0.5);
 }
 
 void AudioNodeScheduler::reset()

--- a/src/core/AudioNode.cpp
+++ b/src/core/AudioNode.cpp
@@ -109,8 +109,12 @@ const char * schedulingStateName(SchedulingState s)
 }
 
 
-const int start_envelope = 64;
-const int end_envelope = 64;
+// Web Audio requires scheduled sources to start/stop instantly at the scheduled time, with no implicit
+// fade. LabSound's 64-frame anti-pop envelope shifted start(t)/stop(t) boundaries by ~64 frames, which the
+// exact-frame offline fixes exposed. 0 == instant start/stop (spec-compliant). Anti-pop, if wanted, belongs
+// in a higher-level gain ramp, not implicitly here.
+const int start_envelope = 0;
+const int end_envelope = 0;
 
 AudioNodeScheduler::AudioNodeScheduler(float sampleRate)
     : _epoch(0)
@@ -124,8 +128,12 @@ bool AudioNodeScheduler::update(ContextRenderLock & r, int epoch_length, const c
 {
     assert(node_name != nullptr);
     uint64_t proposed_epoch = r.context()->currentSampleFrame();
-    if (_epoch >= proposed_epoch)
+    // Force the first update through: the first offline quantum has currentSampleFrame == 0, equal to the
+    // initial _epoch of 0, so the original `>=` early-out skipped it and a start(0) source lost its first
+    // quantum. Subsequent updates keep the `>=` idempotency guard.
+    if (_firstUpdateDone && _epoch >= proposed_epoch)
         return false;
+    _firstUpdateDone = true;
 
     _epoch = proposed_epoch;
     _renderOffset = 0;
@@ -174,8 +182,11 @@ bool AudioNodeScheduler::update(ContextRenderLock & r, int epoch_length, const c
 
             if (_stopWhen <= _epoch)
             {
-                // exactly on start, or late, stop straight away, render a whole frame of fade out
-                _renderLength = epoch_length - _renderOffset;
+                // stop is at or before this quantum's start, so render nothing this quantum. (The original
+                // code rendered a whole quantum for the anti-pop fade-out, but the envelope is now 0;
+                // rendering a whole quantum would make an exact-boundary stop last one quantum too long,
+                // emitting audio at sample == stopWhen.)
+                _renderLength = 0;
                 LOG_PLAYBACK_STATE_TRANSITION(node_name, _playbackState, SchedulingState::STOPPING);
                 _playbackState = SchedulingState::STOPPING;
             }
@@ -239,7 +250,9 @@ void AudioNodeScheduler::start(double when)
         return;
     }
 
-    _startWhen = _epoch + static_cast<uint64_t>(when * _sampleRate);
+    // Round rather than truncate: when * sr such as 1024/44100*44100 = 1023.9999 truncates to 1023,
+    // placing the boundary one frame early.
+    _startWhen = _epoch + static_cast<uint64_t>(when * _sampleRate + 0.5);
     _playbackState = SchedulingState::SCHEDULED;
 }
 
@@ -269,7 +282,8 @@ void AudioNodeScheduler::stop(double when)
         when = 0;
 
     // let the scheduler know when to activate the STOPPING state
-    _stopWhen = _epoch + static_cast<uint64_t>(when * _sampleRate);
+    // Round (as in start()) to avoid a boundary one frame early.
+    _stopWhen = _epoch + static_cast<uint64_t>(when * _sampleRate + 0.5);
 }
 
 void AudioNodeScheduler::reset()

--- a/src/core/ChannelMergerNode.cpp
+++ b/src/core/ChannelMergerNode.cpp
@@ -18,7 +18,7 @@ namespace lab
 
 AudioNodeDescriptor * ChannelMergerNode::desc()
 {
-    static AudioNodeDescriptor d {nullptr, nullptr, 0};
+    static AudioNodeDescriptor d {nullptr, nullptr, 1};
     return &d;
 }
 

--- a/src/core/DelayNode.cpp
+++ b/src/core/DelayNode.cpp
@@ -17,7 +17,7 @@ static AudioSettingDescriptor s_delayTimeSettings[] = {{"delayTime", "DELY", Set
 
 AudioNodeDescriptor * DelayNode::desc()
 {
-    static AudioNodeDescriptor d {nullptr, s_delayTimeSettings, 0};
+    static AudioNodeDescriptor d {nullptr, s_delayTimeSettings, 1};
     return &d;
 }
 


### PR DESCRIPTION
Six independent Web Audio correctness fixes, each in its own commit.

### AnalyserNode: fix ~28KB per-instance heap leak
`shared_construction()` raw-news `_detail` (which owns the `RealtimeAnalyser` and its FFT buffers), but `~AnalyserNode` never freed it, so every `createAnalyser()` orphaned ~28KB that outlived context and engine teardown.

### DelayNode / ChannelMergerNode: default channel count to 1
Both descriptors set `initialChannelCount` to 0, so `AudioNode` initialized `m_channelCount` to 0 and the node rendered zero channels — `DelayNode` produced no output and `ChannelMergerNode` merged into a zero-channel input. Set to 1, matching `GainNode` and `BiquadFilterNode`.

### Offline rendering: align scheduled start/stop and ramps to the exact frame
`OfflineAudioContext` `start(t)`/`stop(t)` and AudioParam ramps could be off by up to a quantum. Five coupled fixes so they land on the exact frame:
- process the first offline quantum (the initial `_epoch == proposed == 0` was skipped by the `>=` early-out);
- `start`/`stop` frame = `round(when * sr)`, not truncate (`1024/44100*44100 = 1023.999` was truncated to 1023);
- start/end envelopes `64 -> 0` (Web Audio sources start/stop instantly, with no implicit anti-pop fade);
- a `PLAYING -> STOPPING` transition exactly on a quantum boundary renders 0, rather than an extra full-volume quantum;
- `offlineRender` advances `current_sample_frame` by exactly one quantum, dropping the odd/even `+index` drift.

### AudioNodeScheduler: schedule start/stop against absolute frames
`start()`/`stop()` computed `_startWhen = _epoch + when * sr`, treating `when` as relative to the scheduler's `_epoch`. Since `_epoch` becomes `currentSampleFrame` once a source has been pulled, an already-connected source started later began at absolute `(currentTime + when)` instead of the spec's absolute `when`, drifting by ~currentTime. This is equivalent for offline rendering (where `_epoch` is 0 at schedule time).

### AudioContext: apply graph edits synchronously for offline contexts
An `OfflineAudioContext` has no render thread while control code runs, so the async pending-connection queue only landed on the first rendered quantum — `connect(...); disconnect(...); startRendering()` rendered a stale topology (disconnected sources stayed audible), and a single-quantum render never observed a disconnect at all. Offline contexts now apply `connect` / `disconnect` / `connectParam` / `disconnectParam` synchronously; realtime contexts keep the async queue (render-thread concurrency + anti-click fade).

### AudioDevice_Miniaudio: reference-count the shared ma_context
The process-wide `g_context` was unconditionally `ma_context_uninit`'d by every `~AudioDevice_Miniaudio`, so a page with two `AudioContext`s (which browsers allow) tore the shared context down twice and aborted in PulseAudio:

```
Assertion 'pa_atomic_load(&(c)->_ref) >= 1' failed at ../src/pulse/context.c:1077
```

The context is now reference-counted behind a mutex (devices may be created and destroyed on different threads); only the last device out calls `ma_context_uninit()`. Devices also track whether `ma_device_init()` succeeded, so a failed-to-open device no longer stop()s and uninit()s a zeroed `ma_device` (the "Unable to stop audio device" noise) or leaks a context reference.

---

## Reproduction and verification

All of these were surfaced through a Web Audio conformance/stress harness driving LabSound; each is reduced below to a self-contained scenario in LabSound terms. Frame numbers assume a 44100 Hz context and the 128-frame render quantum.

**1. AnalyserNode leak** — Repro: in a loop, create an `AudioContext`, `AnalyserNode`, let it settle, then destroy both; sample RSS (or run under `valgrind --leak-check=full` / macOS `leaks`). RSS climbs ~28KB per iteration and never plateaus; the leak report shows the orphaned `AnalyserNode::Detail` / `RealtimeAnalyser`. Verify: after the fix RSS plateaus and the leak report is clean.

**2. DelayNode / ChannelMergerNode silent** — Repro: build an `OfflineAudioContext`, route a non-zero source (e.g. an `OscillatorNode` or a filled `AudioBufferSourceNode`) through a `DelayNode` (then, separately, a `ChannelMergerNode`) into the destination, `startOfflineRendering`, and inspect the rendered `AudioBus`: every sample is 0. Verify: the rendered buffer is non-zero after the fix.

**3. Offline scheduled start/stop off by up to a quantum** — Repro: in an `OfflineAudioContext`, start a source at `when = 0` and render — the first quantum is dropped (silence for frames 0..127). Separately, `stop(when)` at a non-quantum-aligned frame (e.g. `when = 1024/sr`) truncates to frame 1023 and drops the last frame. Verify: `start(0)` produces sound from frame 0, and the stop boundary is sample-exact.

**4. Realtime "connect, then start later" drift** — Repro: on a realtime `AudioContext`, create a source and `connect()` it (so the graph pulls it and `_epoch` advances to `currentSampleFrame`); wait, then call `start(when)` with an absolute time. Playback begins ~`currentTime` late (it started at `currentTime + when`). A create → connect → start-in-one-tick source has `_epoch == 0` and shows no drift, which is why offline and the common case were unaffected. Verify: playback begins at the absolute `when`.

**5. Offline stale topology on disconnect** — Repro (mirrors WPT `audionode-disconnect`): `connect(source, dest); disconnect(source); startOfflineRendering();` — the disconnected source is still present in the rendered buffer. A single-quantum (128-frame) offline render never observes the disconnect at all. Verify: the disconnected source is silent in the rendered buffer.

**6. Miniaudio double-uninit abort with >1 AudioContext** — Repro (Linux, PulseAudio backend): create two realtime `lab::AudioContext` instances (two `AudioDevice_Miniaudio` sharing the process-wide `g_context`), then destroy them. The second destructor calls `ma_context_uninit()` on the already-freed context and the process aborts with `pa_atomic_load(&(c)->_ref) >= 1` failed at `context.c`. (`examples/` `flappybird`-style pages that use one context for SFX and one for music hit this.) Verify: both contexts tear down cleanly; the surviving device no longer renders against a freed context (the intermediate use-after-free is also gone). On macOS/CoreAudio the PulseAudio assertion does not fire, but the same double-`ma_context_uninit()` is fixed.

### Build

Configured and built cleanly on macOS (Release, `cmake -DCMAKE_BUILD_TYPE=Release` → `cmake --build`): core framework plus all backends (miniaudio / RtAudio / mock) and the example, with no new warnings. The repository has no automated test suite (`ctest` reports none), so this could not add CI-registered tests; the scenarios above are the manual reproductions.
